### PR TITLE
Fix login service bean name and cleanup

### DIFF
--- a/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Service;
  *
  *  </pre>
  */
-@Service("loginService")
+@Service("egovLoginService")
 public class EgovLoginServiceImpl extends EgovAbstractServiceImpl implements EgovLoginService {
 
 	@Resource(name = "loginDAO")

--- a/src/main/java/egovframework/let/uat/uia/web/EgovLoginController.java
+++ b/src/main/java/egovframework/let/uat/uia/web/EgovLoginController.java
@@ -39,9 +39,9 @@ import org.springframework.web.context.request.RequestContextHolder;
 @Controller
 public class EgovLoginController {
 
-	/** EgovLoginService */
-	@Resource(name = "loginService")
-	private EgovLoginService loginService;
+    /** EgovLoginService */
+    @Resource(name = "egovLoginService")
+    private EgovLoginService loginService;
 
 	/** EgovMessageSource */
 	@Resource(name = "egovMessageSource")

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -34,9 +34,9 @@
         </property>
 	</bean>
 	
-	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
-		<property name="basePackage" value="kr.co.nanwe,egovframework.com.cmm.service.impl" />
-		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
-	</bean>
+        <bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+                <property name="basePackage" value="kr.co.nanwe,egovframework.com.cmm.service.impl,egovframework.let" />
+                <property name="sqlSessionFactoryBeanName" value="sqlSession" />
+        </bean>
 	
 </beans> 

--- a/src/main/resources/egovframework/spring/egov/context-common.xml
+++ b/src/main/resources/egovframework/spring/egov/context-common.xml
@@ -13,8 +13,8 @@
         http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
         http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
     
-    <context:component-scan base-package="kr.co.nanwe">
-    	<context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller" />
+    <context:component-scan base-package="kr.co.nanwe,egovframework.let">
+        <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller" />
     </context:component-scan>
     
     <bean id="messageSource" class="kr.co.nanwe.cmmn.bean.WildcardReloadableResourceBundleMessageSource">


### PR DESCRIPTION
## Summary
- rename `EgovLoginServiceImpl` bean to `egovLoginService`
- update controller injection name
- scan `egovframework.let` packages in mapper config and component scan
- remove Maven wrapper files that introduced binary jar

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2bbf1e988329a1d509261126960a